### PR TITLE
Split out putting env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can optionally set environment variables from Skpr config.
 
 ```php
 $config = SkprConfig::create()->load();
-$config->putEnvs();
+$config->putAllEnvs();
 ```
 
 Keys will be converted to uppercase, and dots are
@@ -32,12 +32,12 @@ converted to underscores. For example:
 getenv('FOO_BAR')
 ```
 
-You can also provide an include list of config keys, to avoid adding all config as environment
+You can also provide a list of config keys, to avoid adding all config as environment
 variables:
 
 ```php
 $config = SkprConfig::create()->load();
-$config->putEnvs(['my.key']);
+$config->putEnvs(['my.key1', 'my.key2']);
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -9,16 +9,35 @@ The default skpr config directory is /etc/skpr
 
 ## Usage
 
-```
+### Loading config
+
+```php
 $config = SkprConfig::create()->load();
-$config->get('foo.bar')
+$config->get('foo.bar');
 ```
 
-Skipper config variables will be converted to uppercase, and dots are
+### Setting environment variables
+
+You can optionally set environment variables from Skpr config.
+
+```php
+$config = SkprConfig::create()->load();
+$config->putEnvs();
+```
+
+Keys will be converted to uppercase, and dots are
 converted to underscores. For example:
 
 ```
 getenv('FOO_BAR')
+```
+
+You can also provide an include list of config keys, to avoid adding all config as environment
+variables:
+
+```php
+$config = SkprConfig::create()->load();
+$config->putEnvs(['my.key']);
 ```
 
 ## Testing

--- a/src/SkprConfig.php
+++ b/src/SkprConfig.php
@@ -5,7 +5,7 @@ namespace Skpr;
 /**
  * Utility for loading skipper config files.
  */
-class SkprConfig implements \Countable {
+class SkprConfig {
 
   /**
    * The config filename.
@@ -94,7 +94,7 @@ class SkprConfig implements \Countable {
     array_walk($this->config, function ($value, $key) use ($include) {
       // Store as env vars.
       if (empty($include) || in_array($key, $include, TRUE)) {
-        $this->putenv($key, $value);
+        $this->putenv($key);
       }
     });
   }
@@ -104,11 +104,9 @@ class SkprConfig implements \Countable {
    *
    * @param string $key
    *   The config key.
-   * @param string $value
-   *   The config value.
    */
-  public function putEnv($key, $value) {
-    putenv($this->convertToEnvVarName($key) . '=' . $value);
+  public function putEnv($key) {
+    putenv($this->convertToEnvVarName($key) . '=' . $this->get($key));
   }
 
   /**
@@ -255,13 +253,6 @@ class SkprConfig implements \Countable {
     return array_combine(array_map(function (string $name) {
       return $this->convertToEnvVarName($name);
     }, array_keys($this->config)), $this->config);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function count(): int {
-    return count($this->config);
   }
 
 }

--- a/src/SkprConfig.php
+++ b/src/SkprConfig.php
@@ -84,19 +84,25 @@ class SkprConfig {
   }
 
   /**
-   * Puts all Skpr config into env vars.
+   * Puts the list of Skpr config into env vars.
    *
-   * @param string[] $include
-   *   (optional) The list of config keys to include. An empty array will
+   * @param string[] $keys
+   *   The list of config keys to include. An empty array will
    *   include all keys.
    */
-  public function putEnvs(array $include = []) {
-    array_walk($this->config, function ($value, $key) use ($include) {
-      // Store as env vars.
-      if (empty($include) || in_array($key, $include, TRUE)) {
-        $this->putenv($key);
-      }
-    });
+  public function putEnvs(array $keys) {
+    foreach ($keys as $key) {
+      $this->putenv($key);
+    }
+  }
+
+  /**
+   * Puts all Skpr config into env vars.
+   */
+  public function putAllEnvs() {
+    foreach ($this->config as $key => $value) {
+      $this->putenv($key);
+    };
   }
 
   /**

--- a/src/SkprConfig.php
+++ b/src/SkprConfig.php
@@ -5,7 +5,7 @@ namespace Skpr;
 /**
  * Utility for loading skipper config files.
  */
-class SkprConfig {
+class SkprConfig implements \Countable {
 
   /**
    * The config filename.
@@ -85,12 +85,30 @@ class SkprConfig {
 
   /**
    * Puts all Skpr config into env vars.
+   *
+   * @param string[] $include
+   *   (optional) The list of config keys to include. An empty array will
+   *   include all keys.
    */
-  public function putEnvs() {
-    array_walk($this->config, function ($value, $key) {
+  public function putEnvs(array $include = []) {
+    array_walk($this->config, function ($value, $key) use ($include) {
       // Store as env vars.
-      putenv($this->convertToEnvVarName($key) . '=' . $value);
+      if (empty($include) || in_array($key, $include, TRUE)) {
+        $this->putenv($key, $value);
+      }
     });
+  }
+
+  /**
+   * Puts a Skpr config into an env var.
+   *
+   * @param string $key
+   *   The config key.
+   * @param string $value
+   *   The config value.
+   */
+  public function putEnv($key, $value) {
+    putenv($this->convertToEnvVarName($key) . '=' . $value);
   }
 
   /**
@@ -237,6 +255,13 @@ class SkprConfig {
     return array_combine(array_map(function (string $name) {
       return $this->convertToEnvVarName($name);
     }, array_keys($this->config)), $this->config);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function count(): int {
+    return count($this->config);
   }
 
 }

--- a/src/SkprConfig.php
+++ b/src/SkprConfig.php
@@ -79,12 +79,18 @@ class SkprConfig {
         return $this;
       }
       $this->config = json_decode($data, TRUE);
-      array_walk($this->config, function ($value, $key) {
-        // Store as env vars.
-        putenv($this->convertToEnvVarName($key) . '=' . $value);
-      });
     }
     return $this;
+  }
+
+  /**
+   * Puts all Skpr config into env vars.
+   */
+  public function putEnvs() {
+    array_walk($this->config, function ($value, $key) {
+      // Store as env vars.
+      putenv($this->convertToEnvVarName($key) . '=' . $value);
+    });
   }
 
   /**

--- a/tests/Unit/SkprConfigTest.php
+++ b/tests/Unit/SkprConfigTest.php
@@ -18,11 +18,21 @@ class SkprConfigTest extends TestCase {
   public function testLoad() {
     $config = SkprConfig::create()->load(__DIR__ . '/../fixtures/config-link2.json');
     $this->assertEquals('wiz', $config->get('foo.bar'));
-    $this->assertEquals('wiz', getenv('FOO_BAR'));
     $this->assertEquals(NULL, $config->get('does.not.exist'));
     $this->assertEquals('but does have a default', $config->get('does.not.exist', 'but does have a default'));
     $this->assertEquals('squirrel', $config->get('somewhat.secret'));
     $this->assertEquals('sssh', $config->get('super.secret'));
+  }
+
+  /**
+   * @covers ::create
+   * @covers ::load
+   * @covers ::putEnvs
+   */
+  public function testPutEnvs() {
+    $config = SkprConfig::create()->load(__DIR__ . '/../fixtures/config-link2.json');
+    $config->putEnvs();
+    $this->assertEquals('wiz', getenv('FOO_BAR'));
   }
 
   /**

--- a/tests/Unit/SkprConfigTest.php
+++ b/tests/Unit/SkprConfigTest.php
@@ -27,11 +27,11 @@ class SkprConfigTest extends TestCase {
   /**
    * @covers ::create
    * @covers ::load
-   * @covers ::putEnvs
+   * @covers ::putAllEnvs
    */
-  public function testPutEnvs() {
+  public function testPutAllEnvs() {
     $config = SkprConfig::create()->load(__DIR__ . '/../fixtures/config-link2.json');
-    $config->putEnvs();
+    $config->putAllEnvs();
     $this->assertEquals('wiz', getenv('FOO_BAR'));
   }
 
@@ -40,7 +40,7 @@ class SkprConfigTest extends TestCase {
    * @covers ::load
    * @covers ::putEnvs
    */
-  public function testPutEnvsFiltered() {
+  public function testPutEnvs() {
     // Clear env vars.
     putenv('FOO_BAR');
     putenv('SOMEWHAT_SECRET');

--- a/tests/Unit/SkprConfigTest.php
+++ b/tests/Unit/SkprConfigTest.php
@@ -36,6 +36,27 @@ class SkprConfigTest extends TestCase {
   }
 
   /**
+   * @covers ::create
+   * @covers ::load
+   * @covers ::putEnvs
+   */
+  public function testPutEnvsFiltered() {
+    // Clear env vars.
+    putenv('FOO_BAR');
+    putenv('SOMEWHAT_SECRET');
+    putenv('CHIP_SHOP');
+    putenv('SUPER_SECRET');
+
+    $config = SkprConfig::create()->load(__DIR__ . '/../fixtures/config-link2.json');
+    $config->putEnvs(['foo.bar', 'somewhat.secret']);
+
+    $this->assertEquals('wiz', getenv('FOO_BAR'));
+    $this->assertEquals('squirrel', getenv('SOMEWHAT_SECRET'));
+    $this->assertFalse(getenv('CHIP_SHOP'));
+    $this->assertFalse(getenv('SUPER_SECRET'));
+  }
+
+  /**
    * @covers ::getAll
    */
   public function testGetAll() {


### PR DESCRIPTION
Putting Skpr config into env vars should be optional.

Now you need to call:

```php
$config->putAllEnvs();
```
or just to put specific env vars:

```php
$config->putEnvs(['key1', 'key2');
```