### PR TITLE
Fix cache clear for ipranges and hostnames

### DIFF
--- a/src/SkprConfig.php
+++ b/src/SkprConfig.php
@@ -30,7 +30,11 @@ class SkprConfig {
     '/etc/skpr/data',
     '/etc/skpr/data/..data',
     '/etc/skpr/data/..data/config.json',
-    '/etc/skpr/data/config.json',
+    self::CONFIG_FILENAME,
+    '/etc/skpr/data/..data/hostnames.json',
+    self::HOSTNAMES_FILE,
+    '/etc/skpr/data/..data/ip-ranges.json',
+    self::IP_RANGES_FILENAME,
   ];
 
   /**


### PR DESCRIPTION
The php filecache for ip-ranges.json and hostnames.json is not cleared when a new config file gets generated due config updates.

This adds those paths to the list to be cleared from the static file cache.